### PR TITLE
Signal basics, SigTerm/Die

### DIFF
--- a/src/CircoCore.jl
+++ b/src/CircoCore.jl
@@ -308,7 +308,7 @@ abstract type Signal end
 abstract type SignalCause end
 
 """
-    SigTerm(cause=Nothing; die=Nothing)
+    SigTerm(cause=Nothing; exit=Nothing)
 
 Signal to terminate an actor.
 

--- a/src/CircoCore.jl
+++ b/src/CircoCore.jl
@@ -31,7 +31,7 @@ export CircoContext, Scheduler, AbstractScheduler, run!, pause!,
     Event, EventDispatcher, Subscribe, UnSubscribe, fire,
 
     # Signals
-    Die,
+    SigTerm,
 
     # Space
     Pos, pos, nullpos, Infoton, Space
@@ -303,37 +303,11 @@ Plugins.symbol(::Positioner) = :positioner
 function registername end
 function getname end
 
-# lifecycle
-abstract type Signal end
-abstract type SignalCause end
-
-"""
-    SigTerm(cause=Nothing; exit=Nothing)
-
-Signal to terminate an actor.
-
-The default handler terminates the actor without delay.
-
-Also known as `Die`.
-"""
-struct SigTerm <: Signal
-    cause::Union{Nothing, SignalCause}
-    exit::Union{Nothing, Bool} # Whether the scheduler should exit when this was the last actor and no more work
-    SigTerm(cause=nothing; exit=nothing) = new(cause, exit)
-end
-const Die = SigTerm
-
-onmessage(me::Actor, msg::Die, service) = begin
-    @debug "$(box(me)): Dying on" msg
-    die(service, me; exit=isnothing(msg.exit) ? exitwhenlast(me) : msg.exit)
-end
-
-exitwhenlast(me::Actor) = true
-
 
 include("actorstore.jl")
 include("msg.jl")
 include("onmessage.jl")
+include("signal.jl")
 include("zmq_postoffice.jl")
 #include("udp_postoffice.jl")
 include("token.jl")

--- a/src/service.jl
+++ b/src/service.jl
@@ -155,16 +155,19 @@ function become(service::AbstractService, old::Actor, reincarnated::Actor)
 end
 
 """
-    die(service, me::Actor)
+    die(service, me::Actor; exit=false)
 
 Permanently unschedule the actor from its current scheduler.
+
+if `exit` is true and this is the last actor on its scheduler,
+the scheduler will be terminated.
 """
 @inline function die(service::AbstractService, me::Actor; exit = false)
     kill!(service.scheduler, me)    
     if exit    
         if service.scheduler.actorcount <= service.scheduler.startup_actor_count
             service.scheduler.exitflag = true
-            @info "Scheduler's exitflag raised"
+            @debug "Scheduler's exitflag raised"
         end
     end
 end

--- a/src/signal.jl
+++ b/src/signal.jl
@@ -1,0 +1,22 @@
+abstract type Signal end
+
+"""
+    SigTerm(cause=Nothing; exit=Nothing)
+
+Signal to terminate an actor.
+
+The default handler terminates the actor without delay.
+"""
+struct SigTerm <: Signal
+    cause
+    exit::Union{Nothing, Bool} # Whether the scheduler should exit when this was the last actor and no more work
+    SigTerm(cause=nothing; exit=nothing) = new(cause, exit)
+end
+
+onmessage(me::Actor, msg::SigTerm, service) = begin
+    @debug "$(box(me)): Dying on" msg
+    die(service, me; exit=isnothing(msg.exit) ? exitwhenlast(me) : msg.exit)
+end
+
+exitwhenlast(me::Actor) = true
+

--- a/test/signal.jl
+++ b/test/signal.jl
@@ -7,15 +7,13 @@ mutable struct SigTest <: Actor{Any}
 end
 
 @testset "SigTerm" begin
-    @test Die == CircoCore.SigTerm
-
     ctx = CircoContext(;target_module=@__MODULE__)
     tester = SigTest(emptycore(ctx))
     scheduler = Scheduler(ctx, [tester])
     scheduler(;remote = false)
 
     @test CircoCore.is_scheduled(scheduler, tester) == true
-    send(scheduler, tester, Die())
+    send(scheduler, tester, SigTerm())
     actorcount = scheduler.actorcount
     scheduler(;remote = false)
     @test CircoCore.is_scheduled(scheduler, tester) == false

--- a/test/signal.jl
+++ b/test/signal.jl
@@ -12,12 +12,12 @@ end
     ctx = CircoContext(;target_module=@__MODULE__)
     tester = SigTest(emptycore(ctx))
     scheduler = Scheduler(ctx, [tester])
-    scheduler(;remote = false) # to spawn the zygote
+    scheduler(;remote = false)
 
     @test CircoCore.is_scheduled(scheduler, tester) == true
     send(scheduler, tester, Die())
     actorcount = scheduler.actorcount
-    scheduler(;remote = false) # to spawn the zygote
+    scheduler(;remote = false)
     @test CircoCore.is_scheduled(scheduler, tester) == false
     @test scheduler.actorcount == actorcount - 1
 

--- a/test/signal.jl
+++ b/test/signal.jl
@@ -1,0 +1,27 @@
+module SignalTest
+using Test
+using CircoCore
+
+mutable struct SigTest <: Actor{Any}
+    core
+end
+
+@testset "SigTerm" begin
+    @test Die == CircoCore.SigTerm
+
+    ctx = CircoContext(;target_module=@__MODULE__)
+    tester = SigTest(emptycore(ctx))
+    scheduler = Scheduler(ctx, [tester])
+    scheduler(;remote = false) # to spawn the zygote
+
+    @test CircoCore.is_scheduled(scheduler, tester) == true
+    send(scheduler, tester, Die())
+    actorcount = scheduler.actorcount
+    scheduler(;remote = false) # to spawn the zygote
+    @test CircoCore.is_scheduled(scheduler, tester) == false
+    @test scheduler.actorcount == actorcount - 1
+
+    shutdown!(scheduler)
+end
+
+end


### PR DESCRIPTION
Basic infrastructure for handling signals by actors.

The very first signal is `SigTerm`, aka `Die`. When an actor receives it, it should kill itself. By default it does.