### PR TITLE
Reply and Failure Response types

### DIFF
--- a/src/CircoCore.jl
+++ b/src/CircoCore.jl
@@ -22,7 +22,7 @@ export CircoContext, Scheduler, AbstractScheduler, run!, pause!,
     PostCode, postcode, PostOffice, PostException, postoffice, Addr, addr, box, port, AbstractMsg, Msg,
     redirect, body, target, sender, nulladdr,
 
-    Token, TokenId, Tokenized, token, Request, Response, Timeout, settimeout,
+    Token, TokenId, Tokenized, token, Request, Response, Reply, Failure, Timeout, settimeout,
 
     # Actor API
     send, bulksend,

--- a/src/CircoCore.jl
+++ b/src/CircoCore.jl
@@ -22,7 +22,7 @@ export CircoContext, Scheduler, AbstractScheduler, run!, pause!,
     PostCode, postcode, PostOffice, PostException, postoffice, Addr, addr, box, port, AbstractMsg, Msg,
     redirect, body, target, sender, nulladdr,
 
-    Token, TokenId, Tokenized, token, Request, Response, Reply, Failure, Timeout, settimeout,
+    Token, TokenId, Tokenized, token, Request, Response, Failure, Timeout, settimeout,
 
     # Actor API
     send, bulksend,

--- a/src/service.jl
+++ b/src/service.jl
@@ -78,12 +78,12 @@ ballast `service`.
 
 Consistency is just as important as convenience. But performance is king.
 """
-@inline function send(service::AbstractService{TScheduler, TMsg, TCore}, sender, to::Addr, messagebody; kwargs...) where {TScheduler, TMsg, TCore}
+@inline function send(service::AbstractService{TScheduler, TMsg}, sender, to::Addr, messagebody; kwargs...) where {TScheduler, TMsg, TCore}
     message = TMsg(sender, to, messagebody, service.scheduler; kwargs...)
     deliver!(service.scheduler, message)
 end
 
-@inline function send(service::AbstractService{TScheduler, TMsg, TCore}, sender, to::Addr, messagebody::TBody; timeout = 2.0, kwargs...) where {TScheduler, TMsg, TCore, TBody <: Request}
+@inline function send(service::AbstractService{TScheduler, TMsg}, sender, to::Addr, messagebody::Request; timeout = 2.0, kwargs...) where {TScheduler, TMsg}
     settimeout(service.scheduler.tokenservice, Timeout(sender, token(messagebody), timeout))
     message = TMsg(sender, to, messagebody, service.scheduler; kwargs...)
     deliver!(service.scheduler, message)
@@ -164,7 +164,7 @@ if `exit` is true and this is the last actor on its scheduler,
 the scheduler will be terminated.
 """
 @inline function die(service::AbstractService, me::Actor; exit = false)
-    kill!(service.scheduler, me)    
+    kill!(service.scheduler, me)
     if exit    
         if service.scheduler.actorcount <= service.scheduler.startup_actor_count
             service.scheduler.exitflag = true

--- a/src/token.jl
+++ b/src/token.jl
@@ -26,13 +26,6 @@ abstract type Request <: Tokenized end
 abstract type Response <: Tokenized end
 
 """
-    abstract type Reply <: Response end
-
-`Reply` is a type of `Response` that fulfills a `Request` successfully.
-"""
-abstract type Reply <: Response end
-
-"""
     abstract type Failure <: Response end
 
 `Failure` is a type of `Response` to a `Request` that fails to fulfill it.

--- a/src/token.jl
+++ b/src/token.jl
@@ -9,11 +9,35 @@ struct Token
     Token() = new(rand(TokenId))
     Token(id::TokenId) = new(id)
 end
+
+"""
+    abstract type Tokenized end
+
+Tokenized messages can be tracked automatically by the scheduler.
+
+When an actor sends out a [`Request`](@ref), a timeout will be set up
+to track the fulfillment of the request. When a `Response` with the same token
+is received, the timeout will be cancelled. See also: [`send`](@ref).
+"""
 abstract type Tokenized end
 token(t::Tokenized) = t.token
 
 abstract type Request <: Tokenized end
 abstract type Response <: Tokenized end
+
+"""
+    abstract type Reply <: Response end
+
+`Reply` is a type of `Response` that fulfills a `Request` successfully.
+"""
+abstract type Reply <: Response end
+
+"""
+    abstract type Failure <: Response end
+
+`Failure` is a type of `Response` to a `Request` that fails to fulfill it.
+"""
+abstract type Failure <: Response end
 
 struct Timeout
     watcher::Addr

--- a/test/classic.jl
+++ b/test/classic.jl
@@ -74,4 +74,6 @@ using .ClassicTest
     CircoCore.send(s, stackaddr, Pop(coordaddr))
     sleep(0.05)
     @test coordinator.received == Any[43, 42, nothing, nothing]
+
+    CircoCore.shutdown!(s)
 end

--- a/test/token.jl
+++ b/test/token.jl
@@ -22,7 +22,7 @@ mutable struct Requestor{TCore} <: Actor{TCore}
     Requestor(core) = new{typeof(core)}(0, 0, 0, Addr(), core)
 end
 
-struct TReply <: Reply
+struct TReply <: Response
     requestid::UInt64
     token::Token
 end

--- a/test/token.jl
+++ b/test/token.jl
@@ -4,9 +4,8 @@ module TokenTest
 using Test
 using Dates
 using CircoCore
-import CircoCore: onmessage
 
-MESSAGE_COUNT = 100
+MESSAGE_COUNT = 201
 
 struct TRequest <: Request
     id::UInt64
@@ -15,14 +14,20 @@ struct TRequest <: Request
 end
 
 mutable struct Requestor{TCore} <: Actor{TCore}
-    responsecount::Int
+    replycount::Int
+    failurecount::Int
     timeoutcount::Int
     responder::Addr
     core::TCore
+    Requestor(core) = new{typeof(core)}(0, 0, 0, Addr(), core)
 end
-Requestor(core) = Requestor(0, 0, Addr(), core)
 
-struct TResponse <: Response
+struct TReply <: Reply
+    requestid::UInt64
+    token::Token
+end
+
+struct TFailure <: Failure
     requestid::UInt64
     token::Token
 end
@@ -31,34 +36,41 @@ mutable struct Responder{TCore} <: Actor{TCore}
     core::TCore
 end
 
-function onmessage(me::Responder, ::OnSpawn, service)
+CircoCore.onmessage(me::Responder, ::OnSpawn, service) = begin
     registername(service, string(TRequest), me)
 end
 
-function onmessage(me::Requestor, ::OnSpawn, service)
-    registername(service, string(TResponse), me)
+CircoCore.onmessage(me::Requestor, ::OnSpawn, service) = begin
+    registername(service, "requestor", me)
     me.responder = getname(service, string(TRequest))
     for i=1:MESSAGE_COUNT
         send(service, me, me.responder, TRequest(i); timeout = 2.0)
     end
 end
 
-function onmessage(me::Responder, req::TRequest, service)
-    if req.id % 2 == 1
-        send(service, me, getname(service, string(TResponse)), TResponse(req.id, req.token))
+CircoCore.onmessage(me::Responder, req::TRequest, service) = begin
+    if req.id % 3 == 1
+        send(service, me, getname(service, "requestor"), TReply(req.id, req.token))
+    end
+    if req.id % 3 == 2
+        send(service, me, getname(service, "requestor"), TFailure(req.id, req.token))
     end
     if req.id == MESSAGE_COUNT
         die(service, me)
     end
 end
 
-function onmessage(me::Requestor, resp::TResponse, service)
-    me.responsecount += 1
+CircoCore.onmessage(me::Requestor, resp::TReply, service) = begin
+    me.replycount += 1
 end
 
-function onmessage(me::Requestor, timeout::Timeout, service)
+CircoCore.onmessage(me::Requestor, resp::TFailure, service) = begin
+    me.failurecount += 1
+end
+
+CircoCore.onmessage(me::Requestor, timeout::Timeout, service) = begin
     me.timeoutcount += 1
-    if me.timeoutcount == MESSAGE_COUNT / 2
+    if me.timeoutcount == MESSAGE_COUNT / 3
         println("Got $(me.timeoutcount) timeouts, exiting.")
         die(service, me; exit=true)
     end
@@ -71,7 +83,8 @@ end
     scheduler = Scheduler(ctx, [responder, requestor])
     scheduler(;remote=true)
     @test requestor.responder == addr(responder)
-    @test requestor.responsecount == MESSAGE_COUNT / 2
+    @test requestor.replycount == MESSAGE_COUNT / 3
+    @test requestor.failurecount == MESSAGE_COUNT / 3
     @test length(scheduler.tokenservice.timeouts) == 0
     shutdown!(scheduler)
 end


### PR DESCRIPTION
Extend the Response abstract type in order to distinguish errors (called Failures) from successful replies.